### PR TITLE
Update to custom configs

### DIFF
--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -45,7 +45,7 @@ export CFLAGS
 make switch-buildtype-sysinstall
 make %{?_smp_mflags} \
   FAIL_ON_WARNING=1 \
-  EXEC_CONFDIR=%{_sysconfdir}/rcll-refbox \
+  EXEC_CONFDIR=%{_sysconfdir}/rcll-refbox/cfg/ \
   EXEC_BINDIR=%{_bindir} \
   EXEC_LIBDIR=%{_libdir} \
   EXEC_SHAREDIR=%{_datadir}/rcll-refbox \
@@ -56,7 +56,7 @@ make %{?_smp_mflags} \
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/{games,msgs}
-mkdir -p %{buildroot}/%{_sysconfdir}/rcll-refbox
+mkdir -p %{buildroot}/%{_sysconfdir}/rcll-refbox/cfg
 
 install -p ./bin/* %{buildroot}/%{_bindir}/
 find ./lib -type f -exec install -p '{}' %{buildroot}/%{_libdir}/ \;
@@ -65,7 +65,7 @@ install -p ./src/msgs/*.proto %{buildroot}/%{_datadir}/rcll-refbox/msgs
 # TODO: This should be installed in RESDIR nad should be handled by make install.
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
 install -p ./src/libs/websocket/message_schemas/*.json %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
-install -p ./cfg/* %{buildroot}/%{_sysconfdir}/rcll-refbox
+find ./cfg/* -type f -exec install -Dp "{}" "%{buildroot}/%{_sysconfdir}/rcll-refbox/{}" \;
 
 
 %files

--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -65,9 +65,7 @@ install -p ./src/msgs/*.proto %{buildroot}/%{_datadir}/rcll-refbox/msgs
 # TODO: This should be installed in RESDIR and should be handled by make install.
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
 install -p ./src/libs/websocket/message_schemas/*.json %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
-cd cfg
-find * -type f -exec install -Dp "{}" "%{buildroot}/%{_sysconfdir}/rcll-refbox/{}" \;
-cd ..
+cp -a ./cfg/* %{buildroot}/%{_sysconfdir}/rcll-refbox/
 
 %files
 %doc

--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -1,8 +1,8 @@
-%global commit b9d01299faad96548cb5d7d793f27b47bcb460fd
+%global commit d403548448a7a4cf450a034d70f807ff94aefdfd
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 Name:		  rcll-refbox
 Version:	2021
-Release:	0.1.%{shortcommit}%{?dist}
+Release:	0.2.%{shortcommit}%{?dist}
 Summary:	The referee box (refbox) of the RoboCup Logistics League
 
 License:	GPLv2+
@@ -78,6 +78,9 @@ cd ..
 
 
 %changelog
+* Sat Nov  14 15:29:55 CET 2021 Tarik Viehmann <viehmann@kbsg.rwth-aachen.de> - 2021-0.2.f9fe119
+- Update to customizable configuration loading
+
 * Fri May  14 09:33:51 CET 2021 Tarik Viehmann <viehmann@kbsg.rwth-aachen.de> - 2021-0.1.b9d0129
 - Update to latest upstream commit
 

--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -58,7 +58,7 @@ mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/{games,msgs}
 mkdir -p %{buildroot}/%{_sysconfdir}/rcll-refbox/cfg
 
-install -p ./bin/* %{buildroot}/%{_bindir}/
+find ./bin \( -name "llsf*" -o -name "rcll*" \) -exec install -p '{}' %{buildroot}/%{_bindir}/ \;
 find ./lib -type f -exec install -p '{}' %{buildroot}/%{_libdir}/ \;
 cp -a ./src/games/* %{buildroot}/%{_datadir}/rcll-refbox/games
 install -p ./src/msgs/*.proto %{buildroot}/%{_datadir}/rcll-refbox/msgs

--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -58,7 +58,8 @@ mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/{games,msgs}
 mkdir -p %{buildroot}/%{_sysconfdir}/rcll-refbox/cfg
 
-find ./bin \( -name "llsf*" -o -name "rcll*" \) -exec install -p '{}' %{buildroot}/%{_bindir}/ \;
+install -p ./bin/llsf* %{buildroot}/%{_bindir}/
+install -p ./bin/rcll* %{buildroot}/%{_bindir}/
 find ./lib -type f -exec install -p '{}' %{buildroot}/%{_libdir}/ \;
 cp -a ./src/games/* %{buildroot}/%{_datadir}/rcll-refbox/games
 install -p ./src/msgs/*.proto %{buildroot}/%{_datadir}/rcll-refbox/msgs

--- a/rcll-refbox.spec
+++ b/rcll-refbox.spec
@@ -45,7 +45,7 @@ export CFLAGS
 make switch-buildtype-sysinstall
 make %{?_smp_mflags} \
   FAIL_ON_WARNING=1 \
-  EXEC_CONFDIR=%{_sysconfdir}/rcll-refbox/cfg/ \
+  EXEC_CONFDIR=%{_sysconfdir}/rcll-refbox/ \
   EXEC_BINDIR=%{_bindir} \
   EXEC_LIBDIR=%{_libdir} \
   EXEC_SHAREDIR=%{_datadir}/rcll-refbox \
@@ -62,11 +62,12 @@ find ./bin \( -name "llsf*" -o -name "rcll*" \) -exec install -p '{}' %{buildroo
 find ./lib -type f -exec install -p '{}' %{buildroot}/%{_libdir}/ \;
 cp -a ./src/games/* %{buildroot}/%{_datadir}/rcll-refbox/games
 install -p ./src/msgs/*.proto %{buildroot}/%{_datadir}/rcll-refbox/msgs
-# TODO: This should be installed in RESDIR nad should be handled by make install.
+# TODO: This should be installed in RESDIR and should be handled by make install.
 mkdir -p %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
 install -p ./src/libs/websocket/message_schemas/*.json %{buildroot}/%{_datadir}/rcll-refbox/libs/websocket/message_schemas
-find ./cfg/* -type f -exec install -Dp "{}" "%{buildroot}/%{_sysconfdir}/rcll-refbox/{}" \;
-
+cd cfg
+find * -type f -exec install -Dp "{}" "%{buildroot}/%{_sysconfdir}/rcll-refbox/{}" \;
+cd ..
 
 %files
 %doc


### PR DESCRIPTION
This PR attempts to update the fedora package to the latest upstream.
Since this will likely need some minor adjustments to the RefBox that i want to discuss, this is a draft PR for now and the updated commit needs to be adapted before merge.

With the latest RefBox updates all scripts are now symlinked to bin, but i guess they should not all be distributed with the package. They mostly have generic names that are confusing and are not needed for normal refbox usage.
However, the recent challenge startup script is the exception to that.
In order to decide which executables should be packaged i thought the prefixes `rcll` and `llsf` can serve as the defining criteria. All binaries have these prefixes and we could simply rename the startup script to follow the same convention (i created a draft PR for that https://github.com/robocup-logistics/rcll-refbox/pull/112).

Do you think that this is a good idea or should we handle this differently?